### PR TITLE
Implement JSON history diff viewer

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,6 +1,9 @@
 from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
+from django.conf import settings
+from pathlib import Path
+import difflib
 
 from .models import DashboardUser, Position, Role, CustomPermission
 
@@ -112,7 +115,35 @@ def interpreter(request):
 
 @login_required
 def history(request):
-    return render(request, 'dashboard/history.html')
+    media_root = Path(settings.BASE_DIR) / 'media'
+    media_root.mkdir(exist_ok=True)
+    file_names = sorted([f.name for f in media_root.glob('*.json')])
+    file_a = request.GET.get('file_a') or (file_names[0] if file_names else None)
+    file_b = request.GET.get('file_b') or (file_names[1] if len(file_names) > 1 else None)
+
+    lines_a = []
+    lines_b = []
+    removed = set()
+    added = set()
+
+    if file_a and file_b:
+        path_a = media_root / file_a
+        path_b = media_root / file_b
+        if path_a.exists() and path_b.exists():
+            lines_a = path_a.read_text().splitlines()
+            lines_b = path_b.read_text().splitlines()
+            diff = list(difflib.ndiff(lines_a, lines_b))
+            removed = {line[2:] for line in diff if line.startswith('- ')}
+            added = {line[2:] for line in diff if line.startswith('+ ')}
+
+    context = {
+        'file_names': file_names,
+        'file_a': file_a,
+        'file_b': file_b,
+        'lines_a': [{'text': line, 'removed': line in removed} for line in lines_a],
+        'lines_b': [{'text': line, 'added': line in added} for line in lines_b],
+    }
+    return render(request, 'dashboard/history.html', context)
 
 
 @login_required

--- a/media/file1.json
+++ b/media/file1.json
@@ -1,0 +1,5 @@
+{
+  "name": "Project A",
+  "version": 1,
+  "description": "Initial version"
+}

--- a/media/file2.json
+++ b/media/file2.json
@@ -1,0 +1,6 @@
+{
+  "name": "Project A",
+  "version": 2,
+  "description": "Initial version",
+  "status": "updated"
+}

--- a/mvp_project/settings.py
+++ b/mvp_project/settings.py
@@ -137,6 +137,10 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 
+# Media files
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 

--- a/mvp_project/urls.py
+++ b/mvp_project/urls.py
@@ -16,6 +16,8 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 
 
 
@@ -26,3 +28,6 @@ urlpatterns = [
     path('auth/', include('authentication.urls')),
     path('dashboard/', include('dashboard.urls')),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/templates/dashboard/history.html
+++ b/templates/dashboard/history.html
@@ -1,5 +1,34 @@
 {% extends 'dashboard/base_dashboard.html' %}
 {% block title %}History{% endblock %}
 {% block content %}
-<h1 class="text-3xl font-bold">History</h1>
+<h1 class="text-3xl font-bold mb-4">History</h1>
+
+<form method="get" class="mb-4 flex space-x-2">
+    <select name="file_a" class="border p-2 rounded">
+        {% for f in file_names %}
+            <option value="{{ f }}" {% if f == file_a %}selected{% endif %}>{{ f }}</option>
+        {% endfor %}
+    </select>
+    <select name="file_b" class="border p-2 rounded">
+        {% for f in file_names %}
+            <option value="{{ f }}" {% if f == file_b %}selected{% endif %}>{{ f }}</option>
+        {% endfor %}
+    </select>
+    <button type="submit" class="bg-blue-500 text-white px-3 py-1 rounded">Compare</button>
+</form>
+
+<div class="grid grid-cols-2 gap-4">
+    <div class="bg-white p-4">
+        <h2 class="font-bold mb-2">{{ file_a }}</h2>
+        <pre class="text-sm whitespace-pre-wrap">
+{% for line in lines_a %}<span class="{% if line.removed %}text-red-500{% endif %}">{{ line.text }}</span>
+{% endfor %}</pre>
+    </div>
+    <div class="bg-white p-4">
+        <h2 class="font-bold mb-2">{{ file_b }}</h2>
+        <pre class="text-sm whitespace-pre-wrap">
+{% for line in lines_b %}<span class="{% if line.added %}text-green-500{% endif %}">{{ line.text }}</span>
+{% endfor %}</pre>
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show differences between JSON files on the dashboard history page
- highlight additions in green and removals in red
- allow selection of two JSON files for comparison
- serve media files while DEBUG is enabled

## Testing
- `pip install -r requirements.txt` *(fails: 403 Forbidden)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_6866f8930cbc83238b972e0564782c55