### PR TITLE
Improve auth pages with new dark glass style

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -5,7 +5,7 @@ from .models import Profile
 
 
 class SignUpForm(UserCreationForm):
-    base_class = 'w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500'
+    base_class = 'w-full px-4 py-3 rounded-lg bg-white/30 border border-blue-900 text-white placeholder-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-blue-500'
     name = forms.CharField(max_length=150, label='Name',
                            widget=forms.TextInput(attrs={'class': base_class}))
     email = forms.EmailField(label='Email',

--- a/accounts/templates/accounts/login.html
+++ b/accounts/templates/accounts/login.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% block title %}Login - Bob Flow{% endblock %}
 {% block content %}
-<div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-500 via-purple-600 to-indigo-700">
-  <div class="w-full max-w-md px-8 py-12 bg-white bg-opacity-90 backdrop-blur-sm rounded-2xl shadow-xl transform transition-all hover:scale-[1.01]">
+<div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-900 via-blue-800 to-blue-950">
+  <div class="w-full max-w-md px-8 py-12 bg-white/20 backdrop-blur-lg border border-white/30 rounded-2xl shadow-xl">
     <div class="text-center mb-8">
       <div class="flex justify-center mb-4">
         <div class="bg-gradient-to-r from-blue-500 to-indigo-600 p-2 rounded-full">
@@ -11,8 +11,8 @@
           </svg>
         </div>
       </div>
-      <h1 class="text-3xl font-bold text-gray-800 mb-2">Bob Flow</h1>
-      <p class="text-gray-600">Manage your flows with elegance</p>
+      <h1 class="text-3xl font-bold text-white mb-2">Bob Flow</h1>
+      <p class="text-blue-200">Manage your flows with elegance</p>
     </div>
     
     <form method="post" class="space-y-6">
@@ -20,42 +20,70 @@
       
       <div class="space-y-4">
         <div>
-          <label for="username" class="block text-sm font-medium text-gray-700 mb-1">Username</label>
-          <input type="text" name="username" id="username" required 
-                 class="w-full px-4 py-3 rounded-lg border border-gray-300 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition duration-200" 
+          <label for="username" class="block text-sm font-medium text-white mb-1">Username</label>
+          <input type="text" name="username" id="username" required
+                 class="w-full px-4 py-3 rounded-lg bg-white/30 border border-blue-900 text-white placeholder-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                  placeholder="Enter your username">
         </div>
         
         <div>
-          <label for="password" class="block text-sm font-medium text-gray-700 mb-1">Password</label>
-          <input type="password" name="password" id="password" required 
-                 class="w-full px-4 py-3 rounded-lg border border-gray-300 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition duration-200" 
-                 placeholder="Enter your password">
+          <label for="password" class="block text-sm font-medium text-white mb-1">Password</label>
+          <div class="relative">
+            <input type="password" name="password" id="password" required
+                   class="w-full px-4 py-3 pr-10 rounded-lg bg-white/30 border border-blue-900 text-white placeholder-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                   placeholder="Enter your password">
+            <button type="button" onclick="togglePassword()" class="absolute inset-y-0 right-2 flex items-center text-blue-200 hover:text-white">
+              <svg id="eye-open" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+              <svg id="eye-closed" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.27-2.943-9.542-7a9.965 9.965 0 011.666-3.043m3.087-2.85A9.956 9.956 0 0112 5c4.478 0 8.27 2.943 9.542 7a9.973 9.973 0 01-4.29 5.272M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3l18 18" />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
       
       <div class="flex items-center justify-between">
         <div class="flex items-center">
-          <input id="remember-me" name="remember-me" type="checkbox" class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded">
-          <label for="remember-me" class="ml-2 block text-sm text-gray-700">Remember me</label>
+          <input id="remember-me" name="remember-me" type="checkbox" class="h-4 w-4 text-blue-700 focus:ring-blue-500 border-blue-700 rounded bg-white/30">
+          <label for="remember-me" class="ml-2 block text-sm text-blue-200">Remember me</label>
         </div>
         
         <div class="text-sm">
-          <a href="{% url 'password_reset' %}" class="font-medium text-indigo-600 hover:text-indigo-500">Forgot password?</a>
+          <a href="{% url 'password_reset' %}" class="font-medium text-blue-300 hover:text-white">Forgot password?</a>
         </div>
       </div>
       
-      <button type="submit" class="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-200">
+      <button type="submit" class="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gradient-to-r from-blue-700 to-blue-900 hover:from-blue-800 hover:to-blue-950 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-800 transition duration-200">
         Sign in
       </button>
     </form>
     
     <div class="mt-6 text-center">
-      <p class="text-sm text-gray-600">
+      <p class="text-sm text-blue-200">
         Don't have an account?
-        <a href="{% url 'signup' %}" class="font-medium text-indigo-600 hover:text-indigo-500">Sign up</a>
+        <a href="{% url 'signup' %}" class="font-medium text-blue-300 hover:text-white">Sign up</a>
       </p>
     </div>
   </div>
 </div>
+<script>
+  function togglePassword() {
+    const input = document.getElementById('password');
+    const openEye = document.getElementById('eye-open');
+    const closedEye = document.getElementById('eye-closed');
+    if (input.type === 'password') {
+      input.type = 'text';
+      openEye.classList.add('hidden');
+      closedEye.classList.remove('hidden');
+    } else {
+      input.type = 'password';
+      openEye.classList.remove('hidden');
+      closedEye.classList.add('hidden');
+    }
+  }
+</script>
 {% endblock %}

--- a/accounts/templates/accounts/password_reset_complete.html
+++ b/accounts/templates/accounts/password_reset_complete.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% block title %}Password Changed{% endblock %}
 {% block content %}
-<div class="mt-10 text-center">
-    <p>Your password has been reset successfully. <a class="text-indigo-600 hover:underline" href="{% url 'login' %}">Sign in</a>.</p>
+<div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-900 via-blue-800 to-blue-950">
+  <div class="text-center bg-white/20 backdrop-blur-lg border border-white/30 px-8 py-10 rounded-xl shadow-xl">
+    <p class="text-blue-200">Your password has been reset successfully. <a class="text-blue-300 hover:text-white underline" href="{% url 'login' %}">Sign in</a>.</p>
+  </div>
 </div>
 {% endblock %}

--- a/accounts/templates/accounts/password_reset_confirm.html
+++ b/accounts/templates/accounts/password_reset_confirm.html
@@ -1,14 +1,67 @@
 {% extends 'base.html' %}
 {% block title %}New Password{% endblock %}
 {% block content %}
-<div class="flex justify-center mt-10">
-  <div class="w-full max-w-md">
-    <h2 class="text-2xl font-semibold mb-6">Set New Password</h2>
-    <form method="post">
+<div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-900 via-blue-800 to-blue-950">
+  <div class="w-full max-w-md px-8 py-10 bg-white/20 backdrop-blur-lg border border-white/30 rounded-2xl shadow-xl">
+    <h2 class="text-2xl font-semibold text-white mb-6">Set New Password</h2>
+    <form method="post" class="space-y-6">
       {% csrf_token %}
-      {{ form.as_p }}
-      <button type="submit" class="mt-4 bg-indigo-600 hover:bg-indigo-700 text-white py-2 px-4 rounded">Change Password</button>
+      <div>
+        <label for="{{ form.new_password1.id_for_label }}" class="block text-sm font-medium text-white mb-1">New password</label>
+        <div class="relative">
+          <input type="password" name="{{ form.new_password1.html_name }}" id="{{ form.new_password1.id_for_label }}" required class="w-full px-4 py-3 pr-10 rounded-lg bg-white/30 border border-blue-900 text-white placeholder-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+          <button type="button" onclick="togglePassword('{{ form.new_password1.id_for_label }}')" class="absolute inset-y-0 right-2 flex items-center text-blue-200 hover:text-white">
+            <svg id="eye-open-{{ form.new_password1.id_for_label }}" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+            </svg>
+            <svg id="eye-closed-{{ form.new_password1.id_for_label }}" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.27-2.943-9.542-7a9.965 9.965 0 011.666-3.043m3.087-2.85A9.956 9.956 0 0112 5c4.478 0 8.27 2.943 9.542 7a9.973 9.973 0 01-4.29 5.272M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3l18 18" />
+            </svg>
+          </button>
+        </div>
+        {% for error in form.new_password1.errors %}
+        <p class="mt-1 text-xs text-red-400">{{ error }}</p>
+        {% endfor %}
+      </div>
+      <div>
+        <label for="{{ form.new_password2.id_for_label }}" class="block text-sm font-medium text-white mb-1">Confirm password</label>
+        <div class="relative">
+          <input type="password" name="{{ form.new_password2.html_name }}" id="{{ form.new_password2.id_for_label }}" required class="w-full px-4 py-3 pr-10 rounded-lg bg-white/30 border border-blue-900 text-white placeholder-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+          <button type="button" onclick="togglePassword('{{ form.new_password2.id_for_label }}')" class="absolute inset-y-0 right-2 flex items-center text-blue-200 hover:text-white">
+            <svg id="eye-open-{{ form.new_password2.id_for_label }}" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+            </svg>
+            <svg id="eye-closed-{{ form.new_password2.id_for_label }}" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.27-2.943-9.542-7a9.965 9.965 0 011.666-3.043m3.087-2.85A9.956 9.956 0 0112 5c4.478 0 8.27 2.943 9.542 7a9.973 9.973 0 01-4.29 5.272M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3l18 18" />
+            </svg>
+          </button>
+        </div>
+        {% for error in form.new_password2.errors %}
+        <p class="mt-1 text-xs text-red-400">{{ error }}</p>
+        {% endfor %}
+      </div>
+      <button type="submit" class="w-full py-3 px-4 rounded-md shadow-sm text-sm font-medium text-white bg-gradient-to-r from-blue-700 to-blue-900 hover:from-blue-800 hover:to-blue-950 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-800">Change Password</button>
     </form>
   </div>
 </div>
+<script>
+  function togglePassword(id) {
+    const input = document.getElementById(id);
+    const openEye = document.getElementById('eye-open-' + id);
+    const closedEye = document.getElementById('eye-closed-' + id);
+    if (input.type === 'password') {
+      input.type = 'text';
+      openEye.classList.add('hidden');
+      closedEye.classList.remove('hidden');
+    } else {
+      input.type = 'password';
+      openEye.classList.remove('hidden');
+      closedEye.classList.add('hidden');
+    }
+  }
+</script>
 {% endblock %}

--- a/accounts/templates/accounts/password_reset_done.html
+++ b/accounts/templates/accounts/password_reset_done.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% block title %}Email Sent{% endblock %}
 {% block content %}
-<div class="mt-10 text-center">
-    <p>An email with instructions to reset your password has been sent.</p>
+<div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-900 via-blue-800 to-blue-950">
+  <div class="text-center bg-white/20 backdrop-blur-lg border border-white/30 px-8 py-10 rounded-xl shadow-xl">
+    <p class="text-blue-200">An email with instructions to reset your password has been sent.</p>
+  </div>
 </div>
 {% endblock %}

--- a/accounts/templates/accounts/password_reset_form.html
+++ b/accounts/templates/accounts/password_reset_form.html
@@ -1,13 +1,19 @@
 {% extends 'base.html' %}
 {% block title %}Password Recovery{% endblock %}
 {% block content %}
-<div class="flex justify-center mt-10">
-  <div class="w-full max-w-md">
-    <h2 class="text-2xl font-semibold mb-6">Password Recovery</h2>
-    <form method="post">
+<div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-900 via-blue-800 to-blue-950">
+  <div class="w-full max-w-md px-8 py-10 bg-white/20 backdrop-blur-lg border border-white/30 rounded-2xl shadow-xl">
+    <h2 class="text-2xl font-semibold text-white mb-6">Password Recovery</h2>
+    <form method="post" class="space-y-6">
       {% csrf_token %}
-      {{ form.as_p }}
-      <button type="submit" class="mt-4 bg-indigo-600 hover:bg-indigo-700 text-white py-2 px-4 rounded">Send</button>
+      <div>
+        <label for="{{ form.email.id_for_label }}" class="block text-sm font-medium text-white mb-1">Email</label>
+        <input type="email" name="{{ form.email.html_name }}" id="{{ form.email.id_for_label }}" value="{{ form.email.value|default:'' }}" required class="w-full px-4 py-3 rounded-lg bg-white/30 border border-blue-900 text-white placeholder-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+        {% for error in form.email.errors %}
+        <p class="mt-1 text-xs text-red-400">{{ error }}</p>
+        {% endfor %}
+      </div>
+      <button type="submit" class="w-full py-3 px-4 rounded-md shadow-sm text-sm font-medium text-white bg-gradient-to-r from-blue-700 to-blue-900 hover:from-blue-800 hover:to-blue-950 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-800">Send</button>
     </form>
   </div>
 </div>

--- a/accounts/templates/accounts/signup.html
+++ b/accounts/templates/accounts/signup.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% block title %}Sign Up - Bob Flow{% endblock %}
 {% block content %}
-<div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-500 via-purple-600 to-indigo-700 p-4">
-  <div class="w-full max-w-md px-10 py-12 bg-white bg-opacity-90 backdrop-blur-sm rounded-3xl shadow-2xl transform transition-all hover:scale-[1.01]">
+<div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-900 via-blue-800 to-blue-950 p-4">
+  <div class="w-full max-w-md px-10 py-12 bg-white/20 backdrop-blur-lg border border-white/30 rounded-3xl shadow-2xl">
     <div class="text-center mb-10">
       <div class="flex justify-center mb-5">
         <div class="bg-gradient-to-r from-blue-500 to-indigo-600 p-3 rounded-full shadow-lg">
@@ -11,31 +11,52 @@
           </svg>
         </div>
       </div>
-      <h1 class="text-3xl font-bold text-gray-800 mb-2">Create your account</h1>
-      <p class="text-gray-600">Join Bob Flow and simplify your flows</p>
+      <h1 class="text-3xl font-bold text-white mb-2">Create your account</h1>
+      <p class="text-blue-200">Join Bob Flow and simplify your flows</p>
     </div>
     
     <form method="post" class="space-y-6">
       {% csrf_token %}
       
-      <div class="grid gap-6">
+      <div class="grid gap-6 md:grid-cols-2">
         {% for field in form %}
         <div>
-          <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
+          <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-white mb-1">
             {{ field.label }}
             {% if field.field.required %}<span class="text-red-500">*</span>{% endif %}
           </label>
-          <input type="{{ field.field.widget.input_type }}" 
-                 name="{{ field.name }}" 
-                 id="{{ field.id_for_label }}" 
+          {% if field.field.widget.input_type == 'password' %}
+          <div class="relative">
+            <input type="password"
+                   name="{{ field.name }}"
+                   id="{{ field.id_for_label }}"
+                   {% if field.field.required %}required{% endif %}
+                   class="{{ field.field.widget.attrs.class }} pr-10"
+                   placeholder="{{ field.field.widget.attrs.placeholder|default:'' }}">
+            <button type="button" onclick="togglePassword('{{ field.id_for_label }}')" class="absolute inset-y-0 right-2 flex items-center text-blue-200 hover:text-white">
+              <svg id="eye-open-{{ field.id_for_label }}" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+              <svg id="eye-closed-{{ field.id_for_label }}" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.27-2.943-9.542-7a9.965 9.965 0 011.666-3.043m3.087-2.85A9.956 9.956 0 0112 5c4.478 0 8.27 2.943 9.542 7a9.973 9.973 0 01-4.29 5.272M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3l18 18" />
+              </svg>
+            </button>
+          </div>
+          {% else %}
+          <input type="{{ field.field.widget.input_type }}"
+                 name="{{ field.name }}"
+                 id="{{ field.id_for_label }}"
                  {% if field.field.required %}required{% endif %}
-                 class="w-full px-4 py-3 rounded-lg border border-gray-300 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition duration-200"
+                 class="{{ field.field.widget.attrs.class }}"
                  placeholder="{{ field.field.widget.attrs.placeholder|default:'' }}">
+          {% endif %}
           {% if field.help_text %}
-          <p class="mt-1 text-sm text-gray-500">{{ field.help_text }}</p>
+          <p class="mt-1 text-xs text-blue-200">{{ field.help_text }}</p>
           {% endif %}
           {% for error in field.errors %}
-          <p class="mt-1 text-sm text-red-600">{{ error }}</p>
+          <p class="mt-1 text-xs text-red-400">{{ error }}</p>
           {% endfor %}
         </div>
         {% endfor %}
@@ -43,26 +64,40 @@
       
       <div class="flex items-start">
         <div class="flex items-center h-5">
-          <input id="terms" name="terms" type="checkbox" class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded" required>
+          <input id="terms" name="terms" type="checkbox" class="focus:ring-blue-500 h-4 w-4 text-blue-700 border-blue-700 rounded bg-white/30" required>
         </div>
-        <div class="ml-3 text-sm">
-          <label for="terms" class="font-medium text-gray-700">
-            I agree with the <a href="#" class="text-indigo-600 hover:text-indigo-500">Terms of Service</a> and <a href="#" class="text-indigo-600 hover:text-indigo-500">Privacy Policy</a>
-          </label>
+        <div class="ml-3 text-sm text-blue-200">
+          <label for="terms" class="font-medium">I agree with the <a href="#" class="text-blue-300 hover:text-white">Terms of Service</a> and <a href="#" class="text-blue-300 hover:text-white">Privacy Policy</a></label>
         </div>
       </div>
       
-      <button type="submit" class="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-lg font-medium text-white bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-200 transform hover:scale-[1.02]">
+      <button type="submit" class="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-lg font-medium text-white bg-gradient-to-r from-blue-700 to-blue-900 hover:from-blue-800 hover:to-blue-950 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-800 transition duration-200 transform hover:scale-[1.02]">
         Create account
       </button>
     </form>
     
     <div class="mt-8 text-center">
-      <p class="text-sm text-gray-600">
+      <p class="text-sm text-blue-200">
         Already have an account?
-        <a href="{% url 'login' %}" class="font-medium text-indigo-600 hover:text-indigo-500">Sign in</a>
+        <a href="{% url 'login' %}" class="font-medium text-blue-300 hover:text-white">Sign in</a>
       </p>
     </div>
-  </div>
 </div>
+</div>
+<script>
+  function togglePassword(id) {
+    const input = document.getElementById(id);
+    const openEye = document.getElementById('eye-open-' + id);
+    const closedEye = document.getElementById('eye-closed-' + id);
+    if (input.type === 'password') {
+      input.type = 'text';
+      openEye.classList.add('hidden');
+      closedEye.classList.remove('hidden');
+    } else {
+      input.type = 'password';
+      openEye.classList.remove('hidden');
+      closedEye.classList.add('hidden');
+    }
+  }
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- redesign login, signup, and password reset pages with dark glassmorphism
- toggle password visibility with eye icons
- use consistent dark blue palette
- adjust form field classes for new look

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==4.2.23)*

------
https://chatgpt.com/codex/tasks/task_b_6866fc29810c832395b7bf22eee6c5e2