### PR TITLE
Implement dark mode with Tailwind

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,8 +5,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}MVP Project{% endblock %}</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark');
+        }
+        function setIconState() {
+            const icon = document.getElementById('theme-toggle-icon');
+            if (!icon) return;
+            const isDark = document.documentElement.classList.contains('dark');
+            icon.classList.toggle('fa-moon', !isDark);
+            icon.classList.toggle('fa-sun', isDark);
+        }
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.toggle('dark');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            setIconState();
+        }
+        document.addEventListener('DOMContentLoaded', setIconState);
+    </script>
 </head>
-<body>
+<body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
 
 <div class="">
 {% block content %}{% endblock %}

--- a/templates/base_auth.html
+++ b/templates/base_auth.html
@@ -5,8 +5,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Authentication{% endblock %}</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark');
+        }
+        function setIconState() {
+            const icon = document.getElementById('theme-toggle-icon');
+            if (!icon) return;
+            const isDark = document.documentElement.classList.contains('dark');
+            icon.classList.toggle('fa-moon', !isDark);
+            icon.classList.toggle('fa-sun', isDark);
+        }
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.toggle('dark');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            setIconState();
+        }
+        document.addEventListener('DOMContentLoaded', setIconState);
+    </script>
 </head>
-<body class="bg-gray-100">
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
 {% block content %}{% endblock %}
 </body>
 </html>

--- a/templates/dashboard/base_dashboard.html
+++ b/templates/dashboard/base_dashboard.html
@@ -6,8 +6,53 @@
     <title>{% block title %}Dashboard{% endblock %}</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+    <style>
+        :root {
+            --sidebar-start: #1e3a8a;
+            --sidebar-end: #111827;
+            --chart-line-bg: rgba(79, 70, 229, 0.1);
+            --chart-line-color: rgba(79, 70, 229, 1);
+            --donut-color-1: rgba(99, 102, 241, 0.8);
+            --donut-color-2: rgba(14, 165, 233, 0.8);
+            --donut-color-3: rgba(236, 72, 153, 0.8);
+            --donut-color-4: rgba(245, 158, 11, 0.8);
+            --donut-color-5: rgba(16, 185, 129, 0.8);
+        }
+        .dark {
+            --sidebar-start: #172554;
+            --sidebar-end: #0c0f1a;
+            --chart-line-bg: rgba(147, 197, 253, 0.1);
+            --chart-line-color: rgba(147, 197, 253, 1);
+            --donut-color-1: #60a5fa;
+            --donut-color-2: #38bdf8;
+            --donut-color-3: #f472b6;
+            --donut-color-4: #fbbf24;
+            --donut-color-5: #4ade80;
+        }
+    </style>
+    <script>
+        // initialize theme
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark');
+        }
+        function setIconState() {
+            const icon = document.getElementById('theme-toggle-icon');
+            if (!icon) return;
+            const isDark = document.documentElement.classList.contains('dark');
+            icon.classList.toggle('fa-moon', !isDark);
+            icon.classList.toggle('fa-sun', isDark);
+        }
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.toggle('dark');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            if (typeof updateChartColors === 'function') updateChartColors();
+            setIconState();
+        }
+        document.addEventListener('DOMContentLoaded', setIconState);
+    </script>
 </head>
-<body class="bg-gray-100">
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
 <div class="min-h-screen flex">
     {% include 'dashboard/sidebar.html' %}
     <div class="flex-1 flex flex-col">

--- a/templates/dashboard/dashboard.html
+++ b/templates/dashboard/dashboard.html
@@ -187,6 +187,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
   // User Growth Chart
+  const getVar = (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
   const userGrowthCtx = document.getElementById('userGrowthChart').getContext('2d');
   const userGrowthChart = new Chart(userGrowthCtx, {
     type: 'line',
@@ -195,8 +196,8 @@
       datasets: [{
         label: 'New Users',
         data: [12, 19, 15, 27, 34, 42, 48],
-        backgroundColor: 'rgba(79, 70, 229, 0.1)',
-        borderColor: 'rgba(79, 70, 229, 1)',
+        backgroundColor: getVar('--chart-line-bg'),
+        borderColor: getVar('--chart-line-color'),
         borderWidth: 2,
         tension: 0.3,
         fill: true
@@ -227,18 +228,18 @@
       datasets: [{
         data: [35, 30, 15, 10, 10],
         backgroundColor: [
-          'rgba(99, 102, 241, 0.8)',
-          'rgba(14, 165, 233, 0.8)',
-          'rgba(236, 72, 153, 0.8)',
-          'rgba(245, 158, 11, 0.8)',
-          'rgba(16, 185, 129, 0.8)'
+          getVar('--donut-color-1'),
+          getVar('--donut-color-2'),
+          getVar('--donut-color-3'),
+          getVar('--donut-color-4'),
+          getVar('--donut-color-5')
         ],
         borderColor: [
-          'rgba(99, 102, 241, 1)',
-          'rgba(14, 165, 233, 1)',
-          'rgba(236, 72, 153, 1)',
-          'rgba(245, 158, 11, 1)',
-          'rgba(16, 185, 129, 1)'
+          getVar('--donut-color-1'),
+          getVar('--donut-color-2'),
+          getVar('--donut-color-3'),
+          getVar('--donut-color-4'),
+          getVar('--donut-color-5')
         ],
         borderWidth: 1
       }]
@@ -254,5 +255,23 @@
       cutout: '70%'
     }
   });
+
+  function updateChartColors() {
+    userGrowthChart.data.datasets[0].backgroundColor = getVar('--chart-line-bg');
+    userGrowthChart.data.datasets[0].borderColor = getVar('--chart-line-color');
+    userGrowthChart.update();
+
+    const donutColors = [
+      getVar('--donut-color-1'),
+      getVar('--donut-color-2'),
+      getVar('--donut-color-3'),
+      getVar('--donut-color-4'),
+      getVar('--donut-color-5')
+    ];
+    trafficSourcesChart.data.datasets[0].backgroundColor = donutColors;
+    trafficSourcesChart.data.datasets[0].borderColor = donutColors;
+    trafficSourcesChart.update();
+  }
+  document.addEventListener('DOMContentLoaded', updateChartColors);
 </script>
 {% endblock %}

--- a/templates/dashboard/sidebar.html
+++ b/templates/dashboard/sidebar.html
@@ -13,11 +13,11 @@
             transition: all 0.3s ease;
         }
         .gradient-bg {
-            background: linear-gradient(135deg, #1e3a8a 0%, #111827 100%);
+            background: linear-gradient(135deg, var(--sidebar-start) 0%, var(--sidebar-end) 100%);
         }
     </style>
 </head>
-<body class="bg-gray-100">
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
     <div class="flex">
         <!-- Sidebar -->
         <div class="gradient-bg text-white min-h-screen sidebar-transition" 
@@ -25,12 +25,12 @@
              :class="open ? 'w-64' : 'w-20'">
             
             <!-- Logo/Header -->
-            <div class="p-4 flex items-center justify-between border-b border-gray-700">
+            <div class="p-4 flex items-center justify-between border-b border-gray-700 dark:border-gray-600">
                 <div class="flex items-center space-x-2" x-show="open">
                     <i class="fas fa-bolt text-blue-400 text-xl"></i>
                     <span class="text-xl font-bold">BobFlow Build</span>
                 </div>
-                <button @click="open = !open" class="p-2 rounded-full hover:bg-gray-700 transition-all">
+                <button @click="open = !open" class="p-2 rounded-full hover:bg-gray-700 dark:hover:bg-gray-600 transition-all">
                     <i class="fas" :class="open ? 'fa-chevron-left' : 'fa-chevron-right'"></i>
                 </button>
             </div>
@@ -38,14 +38,14 @@
             <!-- Navigation -->
             <nav class="space-y-1 p-2">
                 <!-- Dashboard -->
-                <a href="{% url 'dashboard' %}" class="flex items-center px-4 py-3 rounded-lg hover:bg-gray-700/50 transition-all duration-200 group">
+                <a href="{% url 'dashboard' %}" class="flex items-center px-4 py-3 rounded-lg hover:bg-gray-700/50 dark:hover:bg-gray-600/50 transition-all duration-200 group">
                     <i class="fas fa-tachometer-alt text-lg w-5"></i>
                     <span class="ml-3" x-show="open">Dashboard</span>
                     <span x-show="!open" class="absolute left-14 ml-2 px-2 py-1 text-xs rounded bg-gray-900 text-white opacity-0 group-hover:opacity-100 transition-opacity">Dashboard</span>
                 </a>
                 
                 <!-- Users -->
-                <div x-data="{ isOpen: false }" class="rounded-lg hover:bg-gray-700/50 transition-all duration-200">
+                <div x-data="{ isOpen: false }" class="rounded-lg hover:bg-gray-700/50 dark:hover:bg-gray-600/50 transition-all duration-200">
                     <button @click="isOpen = !isOpen" class="w-full flex items-center justify-between px-4 py-3 group">
                         <div class="flex items-center">
                             <i class="fas fa-users text-lg w-5"></i>
@@ -74,14 +74,14 @@
                 </div>
                 
                 <!-- Positions -->
-                <a href="{% url 'positions' %}" class="flex items-center px-4 py-3 rounded-lg hover:bg-gray-700/50 transition-all duration-200 group">
+                <a href="{% url 'positions' %}" class="flex items-center px-4 py-3 rounded-lg hover:bg-gray-700/50 dark:hover:bg-gray-600/50 transition-all duration-200 group">
                     <i class="fas fa-user-friends text-lg w-5"></i>
                     <span class="ml-3" x-show="open">Positions</span>
                     <span x-show="!open" class="absolute left-14 ml-2 px-2 py-1 text-xs rounded bg-gray-900 text-white opacity-0 group-hover:opacity-100 transition-opacity">Positions</span>
                 </a>
                 
                 <!-- Flow -->
-                <div x-data="{ isOpen: false }" class="rounded-lg hover:bg-gray-700/50 transition-all duration-200">
+                <div x-data="{ isOpen: false }" class="rounded-lg hover:bg-gray-700/50 dark:hover:bg-gray-600/50 transition-all duration-200">
                     <button @click="isOpen = !isOpen" class="w-full flex items-center justify-between px-4 py-3 group">
                         <div class="flex items-center">
                             <i class="fas fa-project-diagram text-lg w-5"></i>
@@ -110,21 +110,21 @@
                 </div>
                 
                 <!-- Interpreter -->
-                <a href="{% url 'interpreter' %}" class="flex items-center px-4 py-3 rounded-lg hover:bg-gray-700/50 transition-all duration-200 group">
+                <a href="{% url 'interpreter' %}" class="flex items-center px-4 py-3 rounded-lg hover:bg-gray-700/50 dark:hover:bg-gray-600/50 transition-all duration-200 group">
                     <i class="fas fa-code text-lg w-5"></i>
                     <span class="ml-3" x-show="open">Interpreter</span>
                     <span x-show="!open" class="absolute left-14 ml-2 px-2 py-1 text-xs rounded bg-gray-900 text-white opacity-0 group-hover:opacity-100 transition-opacity">Interpreter</span>
                 </a>
                 
                 <!-- History -->
-                <a href="{% url 'history' %}" class="flex items-center px-4 py-3 rounded-lg hover:bg-gray-700/50 transition-all duration-200 group">
+                <a href="{% url 'history' %}" class="flex items-center px-4 py-3 rounded-lg hover:bg-gray-700/50 dark:hover:bg-gray-600/50 transition-all duration-200 group">
                     <i class="fas fa-history text-lg w-5"></i>
                     <span class="ml-3" x-show="open">History</span>
                     <span x-show="!open" class="absolute left-14 ml-2 px-2 py-1 text-xs rounded bg-gray-900 text-white opacity-0 group-hover:opacity-100 transition-opacity">History</span>
                 </a>
                 
                 <!-- Settings -->
-                <div x-data="{ isOpen: false }" class="rounded-lg hover:bg-gray-700/50 transition-all duration-200">
+                <div x-data="{ isOpen: false }" class="rounded-lg hover:bg-gray-700/50 dark:hover:bg-gray-600/50 transition-all duration-200">
                     <button @click="isOpen = !isOpen" class="w-full flex items-center justify-between px-4 py-3 group">
                         <div class="flex items-center">
                             <i class="fas fa-cog text-lg w-5"></i>
@@ -153,7 +153,7 @@
                 </div>
                 
                 <!-- Tasks -->
-                <a href="{% url 'tasks' %}" class="flex items-center px-4 py-3 rounded-lg hover:bg-gray-700/50 transition-all duration-200 group">
+                <a href="{% url 'tasks' %}" class="flex items-center px-4 py-3 rounded-lg hover:bg-gray-700/50 dark:hover:bg-gray-600/50 transition-all duration-200 group">
                     <i class="fas fa-tasks text-lg w-5"></i>
                     <span class="ml-3" x-show="open">Tasks</span>
                     <span x-show="!open" class="absolute left-14 ml-2 px-2 py-1 text-xs rounded bg-gray-900 text-white opacity-0 group-hover:opacity-100 transition-opacity">Tasks</span>

--- a/templates/dashboard/topbar.html
+++ b/templates/dashboard/topbar.html
@@ -7,8 +7,8 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header class="bg-white shadow-sm border-b border-gray-100 py-3 px-6">
+<body class="bg-white dark:bg-gray-800 dark:text-gray-100">
+    <header class="bg-white dark:bg-gray-800 dark:text-gray-100 shadow-sm border-b border-gray-100 dark:border-gray-700 py-3 px-6">
         <div class="flex items-center justify-between">
             <!-- Left Section - Page Title and Breadcrumbs -->
             <div class="flex items-center space-x-4">
@@ -30,30 +30,30 @@
                 <!-- Icons Group -->
                 <div class="flex items-center space-x-1">
                     <!-- Notification -->
-                    <button class="p-2 rounded-full hover:bg-gray-100 relative">
+                    <button class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 relative">
                         <i class="fas fa-bell text-gray-600"></i>
                         <span class="absolute top-0 right-0 h-2 w-2 rounded-full bg-red-500 border border-white"></span>
                     </button>
                     
                     <!-- Messages -->
-                    <button class="p-2 rounded-full hover:bg-gray-100 relative">
+                    <button class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 relative">
                         <i class="fas fa-envelope text-gray-600"></i>
                         <span class="absolute top-0 right-0 h-2 w-2 rounded-full bg-blue-500 border border-white"></span>
                     </button>
                     
                     <!-- Fullscreen -->
-                    <button onclick="toggleFullscreen()" class="p-2 rounded-full hover:bg-gray-100 hidden md:block" title="Fullscreen">
+                    <button onclick="toggleFullscreen()" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 hidden md:block" title="Fullscreen">
                         <i class="fas fa-expand text-gray-600"></i>
                     </button>
                     
                     <!-- Dark Mode Toggle -->
-                    <button class="p-2 rounded-full hover:bg-gray-100" title="Toggle Dark Mode">
-                        <i class="fas fa-moon text-gray-600"></i>
+                    <button onclick="toggleTheme()" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700" title="Toggle Dark Mode">
+                        <i id="theme-toggle-icon" class="fas fa-moon text-gray-600 dark:text-gray-300"></i>
                     </button>
                     
                     <!-- Language Selector -->
                     <div class="relative" x-data="{ open: false }">
-                        <button @click="open = !open" class="p-2 rounded-full hover:bg-gray-100 flex items-center">
+                        <button @click="open = !open" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center">
                             <i class="fas fa-globe text-gray-600"></i>
                             <span class="ml-1 text-sm hidden md:inline">EN</span>
                             <i class="fas fa-chevron-down text-xs ml-1 hidden md:inline"></i>
@@ -68,9 +68,9 @@
                              x-transition:leave-start="transform opacity-100 scale-100"
                              x-transition:leave-end="transform opacity-0 scale-95">
                             <div class="py-1">
-                                <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">English</a>
-                                <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Español</a>
-                                <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Français</a>
+                                <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700">English</a>
+                                <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700">Español</a>
+                                <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700">Français</a>
                             </div>
                         </div>
                     </div>
@@ -96,22 +96,22 @@
                                 <p class="text-xs text-gray-500 truncate">john.doe@example.com</p>
                             </div>
                             <div class="py-1">
-                                <a href="{% url 'profile' %}" class="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                                <a href="{% url 'profile' %}" class="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700">
                                     <i class="fas fa-user mr-3 text-gray-500 w-4"></i>
                                     Profile
                                 </a>
-                                <a href="{% url 'configurations' %}" class="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                                <a href="{% url 'configurations' %}" class="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700">
                                     <i class="fas fa-cog mr-3 text-gray-500 w-4"></i>
                                     Settings
                                 </a>
-                                <a href="#" class="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                                <a href="#" class="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700">
                                     <i class="fas fa-envelope mr-3 text-gray-500 w-4"></i>
                                     Messages
                                     <span class="ml-auto bg-blue-500 text-white text-xs px-2 py-0.5 rounded-full">3</span>
                                 </a>
                             </div>
                             <div class="py-1 border-t">
-                                <a href="{% url 'logout' %}" class="flex items-center px-4 py-2 text-sm text-red-600 hover:bg-gray-100">
+                                <a href="{% url 'logout' %}" class="flex items-center px-4 py-2 text-sm text-red-600 hover:bg-gray-100 dark:hover:bg-gray-700">
                                     <i class="fas fa-sign-out-alt mr-3 text-red-500 w-4"></i>
                                     Logout
                                 </a>

--- a/templates/users/users_all.html
+++ b/templates/users/users_all.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="mx-auto px-4 sm:px-6 lg:px-8">
     <!-- Header -->
-    <div class="mb-8 border-b border-gray-200 pb-6">
+    <div class="mb-8 border-b border-gray-200 dark:border-gray-700 pb-6">
         <div class="flex flex-col md:flex-row md:items-center md:justify-between">
             <div>
                 <h1 class="text-2xl font-semibold text-gray-900">User Management</h1>
@@ -20,15 +20,15 @@
     </div>
 
     <!-- Search and Filter Section -->
-    <div class="mb-8 bg-white rounded-lg shadow-xs border border-gray-200 p-6">
+    <div class="mb-8 bg-white dark:bg-gray-800 rounded-lg shadow-xs border border-gray-200 dark:border-gray-700 p-6">
         <form method="get" class="space-y-4">
             <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
                 <!-- Search Field -->
                 <div class="col-span-1 md:col-span-2">
-                    <label for="search" class="block text-sm font-medium text-gray-700 mb-1">Search</label>
+                    <label for="search" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Search</label>
                     <div class="relative rounded-md shadow-sm">
                         <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                            <i class="fas fa-search text-gray-400"></i>
+                            <i class="fas fa-search text-gray-400 dark:text-gray-500"></i>
                         </div>
                         <input 
                             type="text" 
@@ -36,18 +36,18 @@
                             id="search"
                             value="{{ query }}" 
                             placeholder="Name, email or phone..." 
-                            class="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                            class="block w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
                         />
                     </div>
                 </div>
                 
                 <!-- Status Filter -->
                 <div>
-                    <label for="status" class="block text-sm font-medium text-gray-700 mb-1">Status</label>
+                    <label for="status" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Status</label>
                     <select 
                         id="status" 
                         name="status" 
-                        class="block w-full pl-3 pr-10 py-2 text-base border border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
+                        class="block w-full pl-3 pr-10 py-2 text-base border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
                     >
                         <option value="">All Statuses</option>
                         <option value="active">Active</option>
@@ -58,11 +58,11 @@
                 
                 <!-- Date Range Filter -->
                 <div>
-                    <label for="date_range" class="block text-sm font-medium text-gray-700 mb-1">Date Range</label>
+                    <label for="date_range" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Date Range</label>
                     <select 
                         id="date_range" 
                         name="date_range" 
-                        class="block w-full pl-3 pr-10 py-2 text-base border border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
+                        class="block w-full pl-3 pr-10 py-2 text-base border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
                     >
                         <option value="">All Time</option>
                         <option value="today">Today</option>
@@ -78,7 +78,7 @@
                     <button 
                         type="button" 
                         id="clear-filters"
-                        class="inline-flex items-center px-3 py-1.5 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                        class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                     >
                         <i class="fas fa-times mr-1"></i> Clear Filters
                     </button>
@@ -96,12 +96,12 @@
     </div>
 
     <!-- Users Table -->
-    <div class="bg-white shadow-xs rounded-lg border border-gray-200 overflow-hidden">
+    <div class="bg-white dark:bg-gray-800 shadow-xs rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
         <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-700">
                     <tr>
-                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                             User
                         </th>
                         <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -118,23 +118,23 @@
                         </th>
                     </tr>
                 </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
+                <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                     {% for user in users %}
-                    <tr class="hover:bg-gray-50 transition-colors duration-150 ease-in-out">
+                    <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-150 ease-in-out">
                         <td class="px-6 py-4 whitespace-nowrap">
                             <div class="flex items-center">
-                                <div class="flex-shrink-0 h-10 w-10 rounded-full bg-gray-100 flex items-center justify-center">
-                                    <i class="fas fa-user text-gray-500"></i>
+                                <div class="flex-shrink-0 h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
+                                    <i class="fas fa-user text-gray-500 dark:text-gray-300"></i>
                                 </div>
                                 <div class="ml-4">
-                                    <div class="text-sm font-medium text-gray-900">{{ user.name }}</div>
-                                    <div class="text-sm text-gray-500">ID: {{ user.id }}</div>
+                                    <div class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ user.name }}</div>
+                                    <div class="text-sm text-gray-500 dark:text-gray-400">ID: {{ user.id }}</div>
                                 </div>
                             </div>
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
-                            <div class="text-sm text-gray-900">{{ user.email }}</div>
-                            <div class="text-sm text-gray-500">
+                            <div class="text-sm text-gray-900 dark:text-gray-100">{{ user.email }}</div>
+                            <div class="text-sm text-gray-500 dark:text-gray-400">
                                 {% if user.telefone_celular %}
                                     {{ user.telefone_celular }}
                                 {% else %}
@@ -143,11 +143,11 @@
                             </div>
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
                                 Active
                             </span>
                         </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                             Today, 10:45 AM
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
@@ -180,9 +180,9 @@
                     <tr>
                         <td colspan="5" class="px-6 py-4 text-center">
                             <div class="flex flex-col items-center justify-center py-12">
-                                <i class="fas fa-user-slash text-4xl text-gray-300 mb-3"></i>
-                                <h3 class="text-lg font-medium text-gray-900 mb-1">No users found</h3>
-                                <p class="text-gray-500 max-w-md text-center">Try adjusting your search or filter criteria to find what you're looking for.</p>
+                                <i class="fas fa-user-slash text-4xl text-gray-300 dark:text-gray-500 mb-3"></i>
+                                <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">No users found</h3>
+                                <p class="text-gray-500 dark:text-gray-400 max-w-md text-center">Try adjusting your search or filter criteria to find what you're looking for.</p>
                             </div>
                         </td>
                     </tr>
@@ -194,7 +194,7 @@
 
     <!-- Pagination -->
     {% if users.paginator.num_pages > 1 %}
-    <div class="mt-6 flex flex-col sm:flex-row items-center justify-between px-4 py-3 bg-white border-t border-gray-200 sm:px-6 rounded-b-lg">
+    <div class="mt-6 flex flex-col sm:flex-row items-center justify-between px-4 py-3 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 sm:px-6 rounded-b-lg">
         <div class="hidden sm:block">
             <p class="text-sm text-gray-700">
                 Showing <span class="font-medium">{{ users.start_index }}</span> to <span class="font-medium">{{ users.end_index }}</span> of <span class="font-medium">{{ users.paginator.count }}</span> results
@@ -204,12 +204,12 @@
             {% if users.has_previous %}
                 <a 
                     href="?q={{ query }}&page={{ users.previous_page_number }}" 
-                    class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+                    class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"
                 >
                     <i class="fas fa-chevron-left mr-1"></i> Previous
                 </a>
             {% else %}
-                <span class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 text-sm font-medium rounded-md text-gray-400 bg-white cursor-not-allowed">
+                <span class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md text-gray-400 bg-white dark:bg-gray-700 cursor-not-allowed">
                     <i class="fas fa-chevron-left mr-1"></i> Previous
                 </span>
             {% endif %}
@@ -217,12 +217,12 @@
             {% if users.has_next %}
                 <a 
                     href="?q={{ query }}&page={{ users.next_page_number }}" 
-                    class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+                    class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"
                 >
                     Next <i class="fas fa-chevron-right ml-1"></i>
                 </a>
             {% else %}
-                <span class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 text-sm font-medium rounded-md text-gray-400 bg-white cursor-not-allowed">
+                <span class="relative inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md text-gray-400 bg-white dark:bg-gray-700 cursor-not-allowed">
                     Next <i class="fas fa-chevron-right ml-1"></i>
                 </span>
             {% endif %}


### PR DESCRIPTION
## Summary
- add theme variables and dark mode toggle script
- adjust sidebar and topbar for dark mode
- adapt dashboard charts to theme colors
- update base templates for theme switching
- style user management page for dark mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_6867050f704883238f1c031c45c27730